### PR TITLE
Store boosters outside Optuna's storage

### DIFF
--- a/optgbm/sklearn.py
+++ b/optgbm/sklearn.py
@@ -269,6 +269,7 @@ class _VotingBooster(object):
         return np.average(results, axis=0, weights=self.weights)
 
     def dump(self, train_dir: Union[pathlib.Path, str]) -> None:
+        train_dir = str(train_dir)
         train_dir_path = pathlib.Path(train_dir)
 
         train_dir_path.mkdir(exist_ok=True, parents=True)
@@ -281,6 +282,7 @@ class _VotingBooster(object):
 
     @classmethod
     def load(cls, train_dir: Union[pathlib.Path, str]) -> "_VotingBooster":
+        train_dir = str(train_dir)
         train_dir_path = pathlib.Path(train_dir)
         boosters = []
 

--- a/optgbm/sklearn.py
+++ b/optgbm/sklearn.py
@@ -366,7 +366,9 @@ class LGBMModel(lgb.LGBMModel):
         return random_state.randint(0, MAX_INT)
 
     def _get_train_dir(self) -> pathlib.Path:
-        return pathlib.Path(self.train_dir)
+        train_dir = str(self.train_dir)
+
+        return pathlib.Path(train_dir)
 
     def _make_booster(
         self,

--- a/optgbm/sklearn.py
+++ b/optgbm/sklearn.py
@@ -277,7 +277,7 @@ class _VotingBooster(object):
         for i, b in enumerate(self.boosters):
             booster_path = train_dir_path / "fold_{}.pkl".format(i)
 
-            with open(booster_path, "wb") as f:
+            with booster_path.open("wb") as f:
                 pickle.dump(b, f)
 
     @classmethod
@@ -288,7 +288,7 @@ class _VotingBooster(object):
 
         for booster_path in train_dir_path.iterdir():
             if booster_path.match("fold_*.pkl"):
-                with open(booster_path, "rb") as f:
+                with booster_path.open("rb") as f:
                     b = pickle.load(f)
 
                 boosters.append(b)

--- a/optgbm/sklearn.py
+++ b/optgbm/sklearn.py
@@ -877,7 +877,8 @@ class LGBMClassifier(LGBMModel, ClassifierMixin):
     --------
     >>> import optgbm as lgb
     >>> from sklearn.datasets import load_iris
-    >>> clf = lgb.LGBMClassifier(random_state=0)
+    >>> tmp_path = getfixture("tmp_path")  # noqa
+    >>> clf = lgb.LGBMClassifier(random_state=0, train_dir=tmp_path)
     >>> X, y = load_iris(return_X_y=True)
     >>> clf.fit(X, y)
     LGBMClassifier(...)
@@ -1161,7 +1162,8 @@ class LGBMRegressor(LGBMModel, RegressorMixin):
     --------
     >>> import optgbm as lgb
     >>> from sklearn.datasets import load_boston
-    >>> reg = lgb.LGBMRegressor(random_state=0)
+    >>> tmp_path = getfixture("tmp_path")  # noqa
+    >>> reg = lgb.LGBMRegressor(random_state=0, train_dir=tmp_path)
     >>> X, y = load_boston(return_X_y=True)
     >>> reg.fit(X, y)
     LGBMRegressor(...)


### PR DESCRIPTION
In this PR, boosters are overwritten only when the best score is updated.
This behavior reduces execution time and file size.
Exclusive control is required for parallel execution.