### PR TITLE
Fixing check_cv for sklearn 1.0

### DIFF
--- a/optgbm/utils.py
+++ b/optgbm/utils.py
@@ -51,7 +51,7 @@ def check_cv(
         _, counts = np.unique(y, return_counts=True)
         cv = max(2, min(cv, *counts))
 
-    return sklearn_check_cv(cv, y, classifier=classifier)
+    return sklearn_check_cv(cv = cv, y = y, classifier=classifier)
 
 
 def check_X(


### PR DESCRIPTION
The current check_cv throws an error complaining about 3 positional parameters. Not totally clear to me honestly why the existing syntax fails sklearn's positional checks, but this fixes the issue.